### PR TITLE
Added bundling support via noderify + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 settings.json
 .idea
+dist

--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -1,0 +1,35 @@
+# Bundled distribution
+
+## Introduction
+
+That is a single JavaScript file which contains LR source code and the most of `node_modules` 
+dependencies.
+
+It is intended to deploy those bundles instead of full-blown source code and `node_modules` to 
+the boards. This provides some benefits, like faster bootstraping (no need to do many filesystem 
+lookups for loading CommonJS modules), less `node_modules` directory size on a board (which is 
+significant on slow boards).
+
+## Maintenance
+
+However, some npm packages cannot be bundled (see the `build:index.js` script in the 
+`/package.json`), such as:
+
+- `log4js` - loads appenders from a filesystem
+- `nconf` - loads stores from a filesystem 
+- `ideino-linino-lib` - Arduino Yun specific - not needed on other boards
+- `node-reverse-wstunnel` - is used by LR as a program, not as a CommonJS module.
+
+So these non-bundled dependencies are still required to be installed on a board. For convenience,
+they're listed in the `/package.dist.json` file. It it important to keep it in sync with the 
+`/package.json`.
+
+## Usage
+
+- `npm install` - Installs all the required dependencies from the `/package.json` locally.
+- `npm run build` - Builds a bundled distribution to the `/dist` folder with a bundle (`index.js`) 
+and a `package.json` with all the non-bundled dependencies.
+- Transfer the `/dist` directory to a board.
+- `cd` to that directory on a board and run `npm install` to install non-bundled dependencies 
+locally.
+- Use `npm start` to launch the LR, or simply `node index.js`.

--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -17,9 +17,11 @@ However, some npm packages cannot be bundled (see the `build:index.js` script in
 
 - `log4js` - loads appenders from a filesystem
 - `nconf` - loads stores from a filesystem 
-- `fuse-bindings` - contains binary objects
-- `ideino-linino-lib` - Arduino Yun specific - not needed on other boards
 - `node-reverse-wstunnel` - is used by LR as a program, not as a CommonJS module.
+- `ideino-linino-lib` - Arduino Yun specific - not needed on other boards. Must be installed 
+manually.
+- `fuse-bindings` - Platform-specific, contains binary objects. Not needed on Android. Must be 
+installed manually.
 
 So these non-bundled dependencies are still required to be installed on a board. For convenience,
 they're listed in the `/package.dist.json` file. It it important to keep it in sync with the 

--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -17,6 +17,7 @@ However, some npm packages cannot be bundled (see the `build:index.js` script in
 
 - `log4js` - loads appenders from a filesystem
 - `nconf` - loads stores from a filesystem 
+- `fuse-bindings` - contains binary objects
 - `ideino-linino-lib` - Arduino Yun specific - not needed on other boards
 - `node-reverse-wstunnel` - is used by LR as a program, not as a CommonJS module.
 

--- a/package.dist.json
+++ b/package.dist.json
@@ -1,0 +1,15 @@
+{
+  "name": "s4t-lightning-rod-dist",
+  "version": "0.0.0",
+  "private": true,
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "log4js": ">=0.6.33",
+    "nconf": ">=0.7.1",
+    "node-reverse-wstunnel": ">=0.1.2"
+  }
+}

--- a/package.dist.json
+++ b/package.dist.json
@@ -8,6 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "fuse-bindings": "^2.11.0",
     "log4js": ">=0.6.33",
     "nconf": ">=0.7.1",
     "node-reverse-wstunnel": ">=0.1.2"

--- a/package.dist.json
+++ b/package.dist.json
@@ -8,7 +8,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "fuse-bindings": "^2.11.0",
     "log4js": ">=0.6.33",
     "nconf": ">=0.7.1",
     "node-reverse-wstunnel": ">=0.1.2"

--- a/package.json
+++ b/package.json
@@ -4,17 +4,25 @@
   "description": "Implementation of the Lightning-rod, the Stack4Things node-side probe (this version works with the standalone version of IoTronic) http://stack4things.unime.it/",
   "main": "lightning-rod.js",
   "scripts": {
-    "test": "node lightning-rod.js"
+    "test": "node lightning-rod.js",
+    "copy:package.dist.json": "cp package.dist.json dist/package.json",
+    "build:index.js": "noderify -f nconf -f log4js -f ideino-linino-lib lightning-rod.js > dist/index.js",
+    "build": "npm run clean && mkdir -p dist && npm run build:index.js && npm run copy:package.dist.json",
+    "clean": "rimraf dist"
   },
-  "dependencies":{
-    "node-reverse-wstunnel": ">=0.1.2",
+  "dependencies": {
     "autobahn": ">=0.9.6",
-    "nconf":">=0.7.1",
-    "requestify":">=0.1.17",
-    "is-running":">=2.0.0",
-    "connection-tester":">=0.1.0",
-    "log4js":">=0.6.33",
-    "q":">=0.9.7"
+    "connection-tester": ">=0.1.0",
+    "is-running": ">=2.0.0",
+    "log4js": ">=0.6.33",
+    "nconf": ">=0.7.1",
+    "node-reverse-wstunnel": ">=0.1.2",
+    "q": ">=0.9.7",
+    "requestify": ">=0.1.17"
+  },
+  "devDependencies": {
+    "noderify": "^2.0.0",
+    "rimraf": "^2.6.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "test": "node lightning-rod.js",
     "copy:package.dist.json": "cp package.dist.json dist/package.json",
-    "build:index.js": "noderify -f nconf -f log4js -f ideino-linino-lib lightning-rod.js > dist/index.js",
+    "build:index.js": "noderify -f nconf -f log4js -f fuse-bindings -f ideino-linino-lib lightning-rod.js > dist/index.js",
     "build": "npm run clean && mkdir -p dist && npm run build:index.js && npm run copy:package.dist.json",
     "clean": "rimraf dist"
   },
   "dependencies": {
     "autobahn": ">=0.9.6",
     "connection-tester": ">=0.1.0",
+    "fuse-bindings": "^2.11.0",
     "is-running": ">=2.0.0",
     "log4js": ">=0.6.33",
     "nconf": ">=0.7.1",


### PR DESCRIPTION
We have started this discussion in the "Packing LR as an APK" task at Producteev.

Bundling distribution is crucial for Android platform, without it bootstrapping takes ~3 minutes, but a bundle gets loaded in less than 10 seconds -- there's still room for optimization.

I hope I've explained everything clear in the `docs/bundling.md` file, but feel free to ask questions and maybe correct some English typos in the doc.

After merging this, docs for Arduino Yun and Raspberry Pi boards might be rewritten taking into account this variant of deployment.